### PR TITLE
Add functions to configure the MPU for privileged mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-mpu"
-version = "0.4.0"
+version = "0.5.0"
 description = """
 An interface for the Memory Protection Unit (MPU) in Cortex-M microcontrollers
 """
@@ -12,7 +12,7 @@ keywords = ["memory", "cortex", "arm", "mpu", "mcu"]
 categories = ["embedded", "no-std"]
 
 [dependencies]
-cortex-m = "0.6.1"
+cortex-m = "0.7.6"
 arrayvec = { version = "0.4.11", default-features = false }
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,6 +462,7 @@ pub enum AccessPermission {
 }
 
 /// Data access permissions for privileged and unprivileged modes
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FullAccessPermissions {
     /// Any access generates a permission fault
     PrivilegedNoAccessUnprivilegedNoAccess = 0b000,


### PR DESCRIPTION
# Motivation

Even when using only privileged-mode code in an application, the MPU can be useful to detect stack overflow and other memory access problems. For this to work, the MPU needs to restrict privileged-mode code.

# Proposed changes

I propose to add a `configure` function in the M0 and M4 modules that can configure access permissions for both privileged and unprivileged modes in all the combinations that the hardware supports.

This is not a breaking change. The existing `Region` struct and `configure_unprivileged` functions can still be used as before.

The updated code is working correctly on my Cortex-M4 microcontroller.